### PR TITLE
Allow building with GHC 9.8

### DIFF
--- a/s-cargot-letbind.cabal
+++ b/s-cargot-letbind.cabal
@@ -55,7 +55,7 @@ library
   exposed-modules:     Data.SCargot.LetBind
   build-depends:       base      >=4.9 && <5
                      , s-cargot  >= 0.1.6.0 && <0.2
-                     , text      >=1.2 && <2.1
+                     , text      >=1.2 && <2.2
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall
@@ -70,4 +70,4 @@ test-suite s-cargot-printparselet
                   , HUnit     >=1.6 && <1.7
                   , s-cargot  >= 0.1.6.0 && <0.2
                   , s-cargot-letbind
-                  , text      >=1.2 && <2.1
+                  , text      >=1.2 && <2.2

--- a/src/Data/SCargot/LetBind.hs
+++ b/src/Data/SCargot/LetBind.hs
@@ -21,6 +21,7 @@ import           Control.Applicative
 import qualified Data.Foldable as F
 import           Data.Function (on)
 import           Data.List ( sortBy, intercalate )
+import qualified Data.List.NonEmpty as NE
 import           Data.Maybe
 import           Data.Monoid
 import           Data.SCargot.Repr
@@ -183,14 +184,15 @@ alwaysBindWeight = 1000000
 
 bestBindings :: DiscoveryGuide a str -> ExprInfo a -> [Location a] -> [Location a]
 bestBindings guide exprs locs = getMaxBest
-    where getMaxBest = head $
+    where getMaxBest = NE.head $
                        -- Sometimes a lengthy binding "swallows"
                        -- everything else; skipping over it would
                        -- result in more available bindings.  Try the
                        -- first 3 combinations and take the one
                        -- yielding the most bindings.
-                       sortBy (compare `on` length) $
-                       fmap getBestSkipping [0..2]
+                       NE.sortBy (compare `on` length) $
+                       fmap getBestSkipping $
+                       0 NE.:| [1, 2]
           getBestSkipping n = snd $ snd $  -- extract list of Locations
                               -- determine top-set of best bindings to apply
                               foldl bestB (n, (maxbinds, [])) $


### PR DESCRIPTION
Bump the upper version bounds to allow building with `bytestring-0.12.*` and `text-2.1.*`, which are bundled with GHC 9.8. Also fix a `-Wx-partial` warning caused by a use of the `head` function.